### PR TITLE
Renamed scheduler ClusterRoleBinding

### DIFF
--- a/rolebindings/sceduler-read-all-rb.yaml
+++ b/rolebindings/sceduler-read-all-rb.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  name: scheduler-role-binding
+  name: scheduler-role-binding--read-all
 subjects:
   - kind: User
     name: system:scheduler


### PR DESCRIPTION
In K8s 1.4.7 when I tried to apply the files as is (with #2's patch applied) results in `The ClusterRoleBinding "scheduler-role-binding" is invalid: roleRef: Invalid value: {"kind":"ClusterRole","name":"scheduler"}: cannot change roleRef` due to both files `sceduler-read-all-rb.yaml` and `scheduler-role-binding.yaml` using the same metadata.name so one file reconfigured the other.